### PR TITLE
Add option to disable deprecated mappings.

### DIFF
--- a/plugin/WindowSwap.vim
+++ b/plugin/WindowSwap.vim
@@ -6,10 +6,16 @@ if !exists('g:windowswap_mapping_deprecation_notice')
    let g:windowswap_mapping_deprecation_notice = 0
 endif
 
+if !exists('g:windowswap_enable_deprecated_mappings')
+   let g:windowswap_enable_deprecated_mappings = 1
+endif
+
 if g:windowswap_map_keys
    nnoremap <silent> <leader>ww :call WindowSwap#EasyWindowSwap()<CR>
-   nnoremap <silent> <leader>yw :call WindowSwap#DeprecatedMark()<CR>
-   nnoremap <silent> <leader>pw :call WindowSwap#DeprecatedDo()<CR>
+   if g:windowswap_enable_deprecated_mappings
+      nnoremap <silent> <leader>yw :call WindowSwap#DeprecatedMark()<CR>
+      nnoremap <silent> <leader>pw :call WindowSwap#DeprecatedDo()<CR>
+   endif
 endif
 
 let g:loaded_windowswap = 1


### PR DESCRIPTION
I didn't like seeing the deprecated mappings when running `nnoremap <leader>` so I
made this PR, what do you think?